### PR TITLE
Fixed some grammar mistakes

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/procedures/auto-implemented-properties.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/auto-implemented-properties.md
@@ -48,9 +48,9 @@ End Class
  Você pode atribuir a propriedade com expressões de inicialização, conforme mostrado no exemplo, ou você pode atribuir às propriedades do construtor do tipo recipiente.  Você pode atribuir aos campos de backup propriedades somente leitura a qualquer momento.  
   
 ## <a name="backing-field"></a>Campo de backup  
- Quando você declara uma propriedade implementada automaticamente, o Visual Basic cria automaticamente um campo particular oculto chamado o *campo de backup* para conter o valor da propriedade. O nome do campo de backup é o nome da propriedade implementada automaticamente precedido por um *underline* (_). Por exemplo, se você declarar uma propriedade implementada automaticamente denominada `ID`, o campo de backup é denominado `_ID`. Se você incluir um membro da sua classe que também é chamado `_ID`, isso irá produzir um conflito de nomeação e o Visual Basic vai relatar um erro de compilação.  
+ Quando você declara uma propriedade implementada automaticamente, o Visual Basic cria automaticamente um campo particular oculto chamado o *campo de suporte* para conter o valor da propriedade. O nome do campo de suporte é o nome da propriedade implementada automaticamente precedido por um *sublinhado* (_). Por exemplo, se você declarar uma propriedade implementada automaticamente denominada `ID`, o campo de suporte é denominado `_ID`. Se você incluir um membro da sua classe que também é chamado `_ID`, isso produzirá um conflito de nomeação e o Visual Basic vai relatar um erro de compilação.
   
- O campo de backup também tem as seguintes características:  
+ O campo de suporte também tem as seguintes características: 
   
 -   O modificador de acesso para o campo de backup é sempre `Private`, mesmo quando a própria propriedade tem um nível de acesso diferentes, como `Public`.  
   
@@ -58,7 +58,7 @@ End Class
   
 -   Atributos especificados para a propriedade não se aplicam ao campo de backup.  
   
--   O campo de backup pode ser acessado do código dentro da classe e de ferramentas de depuração, como a janela de inspeção. No entanto, o campo de backup não aparece na lista de sugestões do IntelliSense word.  
+-   O campo de suporte pode ser acessado do código dentro da classe e de ferramentas de depuração, como a janela de inspeção. No entanto, o campo de suporte não aparece na lista de conclusão do IntelliSense word. 
   
 ## <a name="initializing-an-auto-implemented-property"></a>Inicializando uma propriedade implementada automaticamente  
  Qualquer expressão que pode ser usada para inicializar um campo é válida para a inicialização de uma propriedade implementada automaticamente. Quando você inicializa uma propriedade implementada automaticamente, a expressão é avaliada e passada para o `Set` procedimento para a propriedade. Os exemplos de código a seguir mostram algumas propriedades autoimplementadas que incluem valores iniciais.  

--- a/docs/visual-basic/programming-guide/language-features/procedures/auto-implemented-properties.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/auto-implemented-properties.md
@@ -17,7 +17,7 @@ ms.lasthandoff: 05/04/2018
 ms.locfileid: "33656302"
 ---
 # <a name="auto-implemented-properties-visual-basic"></a>Propriedades autoimplementadas (Visual Basic)
-*Propriedades autoimplementadas* permitem que você especificar uma propriedade de uma classe rapidamente sem a necessidade de escrever código para `Get` e `Set` a propriedade. Quando você escrever código para uma propriedade implementada automaticamente, o compilador do Visual Basic cria automaticamente um campo particular para armazenar a variável de propriedade, além de criar associado `Get` e `Set` procedimentos.  
+*Propriedades autoimplementadas* permitem que você especifique uma propriedade de uma classe rapidamente sem a necessidade de escrever código para as propriedades `Get` e `Set`. Quando você escreve código criando uma propriedade implementada automaticamente, o compilador do Visual Basic cria automaticamente um campo *private* para armazenar a variável de propriedade, além de criar os procedimentos `Get` e `Set` associados.  
   
  Com Propriedades autoimplementadas, uma propriedade, incluindo um valor padrão, pode ser declarada em uma única linha. O exemplo a seguir mostra três declarações de propriedade.  
   
@@ -31,7 +31,7 @@ ms.locfileid: "33656302"
   
  [!code-vb[VbVbalrAutoImplementedProperties#2](./codesnippet/VisualBasic/auto-implemented-properties_3.vb)]  
   
- O código a seguir mostram como implementar propriedades somente leitura:  
+ O código a seguir mostra como implementar propriedades somente leitura:  
   
 ```vb  
 Class Customer  
@@ -45,12 +45,12 @@ Class Customer
 End Class  
 ```  
   
- Você pode atribuir a propriedade com expressões de inicialização, conforme mostrado no exemplo a, ou você pode atribuir às propriedades do construtor do tipo recipiente.  Você pode atribuir aos campos de backup propriedades somente leitura a qualquer momento.  
+ Você pode atribuir a propriedade com expressões de inicialização, conforme mostrado no exemplo, ou você pode atribuir às propriedades do construtor do tipo recipiente.  Você pode atribuir aos campos de backup propriedades somente leitura a qualquer momento.  
   
 ## <a name="backing-field"></a>Campo de backup  
- Quando você declara uma propriedade implementada automaticamente, o Visual Basic cria automaticamente um campo particular oculto chamado o *campo existente* para conter o valor da propriedade. O nome do campo de backup é o nome da propriedade implementada automaticamente precedido por um sublinhado (_). Por exemplo, se você declarar uma propriedade implementada automaticamente denominada `ID`, o campo de backup é denominado `_ID`. Se você incluir um membro da sua classe que também é denominada `_ID`, produzir um conflito de nomeação e Visual Basic relata um erro do compilador.  
+ Quando você declara uma propriedade implementada automaticamente, o Visual Basic cria automaticamente um campo particular oculto chamado o *campo de backup* para conter o valor da propriedade. O nome do campo de backup é o nome da propriedade implementada automaticamente precedido por um *underline* (_). Por exemplo, se você declarar uma propriedade implementada automaticamente denominada `ID`, o campo de backup é denominado `_ID`. Se você incluir um membro da sua classe que também é chamado `_ID`, isso irá produzir um conflito de nomeação e o Visual Basic vai relatar um erro de compilação.  
   
- O campo de reforço também tem as seguintes características:  
+ O campo de backup também tem as seguintes características:  
   
 -   O modificador de acesso para o campo de backup é sempre `Private`, mesmo quando a própria propriedade tem um nível de acesso diferentes, como `Public`.  
   
@@ -58,10 +58,10 @@ End Class
   
 -   Atributos especificados para a propriedade não se aplicam ao campo de backup.  
   
--   O campo de backup pode ser acessado de código dentro da classe e de ferramentas de depuração, como a janela inspeção. No entanto, o campo de reforço não mostrar em uma lista de conclusão do IntelliSense word.  
+-   O campo de backup pode ser acessado do código dentro da classe e de ferramentas de depuração, como a janela de inspeção. No entanto, o campo de backup não aparece na lista de sugestões do IntelliSense word.  
   
 ## <a name="initializing-an-auto-implemented-property"></a>Inicializando uma propriedade implementada automaticamente  
- Qualquer expressão que pode ser usado para inicializar um campo é válido para a inicialização de uma propriedade implementada automaticamente. Quando você inicializa uma propriedade implementada automaticamente, a expressão é avaliada e passada para o `Set` procedimento para a propriedade. Os exemplos de código a seguir mostram algumas propriedades autoimplementadas que incluem valores iniciais.  
+ Qualquer expressão que pode ser usada para inicializar um campo é válida para a inicialização de uma propriedade implementada automaticamente. Quando você inicializa uma propriedade implementada automaticamente, a expressão é avaliada e passada para o `Set` procedimento para a propriedade. Os exemplos de código a seguir mostram algumas propriedades autoimplementadas que incluem valores iniciais.  
   
  [!code-vb[VbVbalrAutoImplementedProperties#3](./codesnippet/VisualBasic/auto-implemented-properties_4.vb)]  
   

--- a/docs/visual-basic/programming-guide/language-features/procedures/how-to-protect-a-procedure-argument-against-value-changes.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/how-to-protect-a-procedure-argument-against-value-changes.md
@@ -22,12 +22,12 @@ ms.lasthandoff: 05/04/2018
 ms.locfileid: "33651512"
 ---
 # <a name="how-to-protect-a-procedure-argument-against-value-changes-visual-basic"></a>Como proteger um argumento de procedimento contra alterações de valor (Visual Basic)
-Se um procedimento declara um parâmetro como [ByRef](../../../../visual-basic/language-reference/modifiers/byref.md), o Visual Basic passa para o procedimento uma referência direta para o elemento de programação subjacente do argumento no código de chamada. Isso permite que o procedimento altere o valor subjacente do argumento no código de chamada. Em alguns casos, o código de chamada talvez queira estar protegido contra essa alteração.  
+Se um procedimento declara um parâmetro como [ByRef](../../../../visual-basic/language-reference/modifiers/byref.md), o Visual Basic fornece ao código do procedimento uma referência direta para o elemento de programação subjacente do argumento no código de chamada. Isso permite que o procedimento altere o valor subjacente do argumento no código de chamada. Em alguns casos, o código de chamada talvez queira estar protegido contra essa alteração.
   
  Você pode proteger um argumento de alteração, declarando o parâmetro correspondente com a palavra-chave [ByVal](../../../../visual-basic/language-reference/modifiers/byval.md) no procedimento. Se desejar alterar um argumento fornecido em alguns casos, mas outros não, você pode declará-la `ByRef` e permitir que o código de chamada determine o mecanismo de passagem em cada chamada. Ele faz isso colocando o argumento correspondente entre parênteses para passá-lo por valor, ou não envolvendo em parênteses para passá-lo por referência. Para obter mais informações, consulte [como: forçar um argumento a ser passado por valor](./how-to-force-an-argument-to-be-passed-by-value.md).  
   
 ## <a name="example"></a>Exemplo  
- O exemplo a seguir mostra dois procedimentos que tem uma variável de matriz e operam em seus elementos. O procedimento `increase` simplesmente adiciona um para cada elemento. O procedimento `replace` atribui uma nova matriz para o parâmetro `a()` e, em seguida, adiciona um para cada elemento. No entanto, a reatribuição não afeta a variável da array subjacente no código de chamada.  
+ O exemplo a seguir mostra dois procedimentos que têm uma variável de matriz e operam em seus elementos. O procedimento `increase` simplesmente adiciona um para cada elemento. O procedimento `replace` atribui uma nova matriz para o parâmetro `a()` e, em seguida, adiciona um para cada elemento. No entanto, a reatribuição não afeta a variável da array subjacente no código de chamada.
   
  [!code-vb[VbVbcnProcedures#35](./codesnippet/VisualBasic/how-to-protect-a-procedure-argument-against-value-changes_1.vb)]  
   
@@ -35,7 +35,7 @@ Se um procedimento declara um parâmetro como [ByRef](../../../../visual-basic/l
   
  [!code-vb[VbVbcnProcedures#37](./codesnippet/VisualBasic/how-to-protect-a-procedure-argument-against-value-changes_3.vb)]  
   
- A primeira `MsgBox` chamada exibe "após increase (n): 11, 21, 31, 41". Porque a matriz `n` é um tipo de referência, `increase` pode alterar seus membros, mesmo que o mecanismo de passagem é `ByVal`.  
+ A primeira `MsgBox` chamada exibe "após increase (n): 11, 21, 31, 41". Porque a matriz `n` é um tipo de referência, `replace` pode alterar seus membros, mesmo que o mecanismo de passagem é `ByVal`.
   
  A segunda `MsgBox` chamada exibe "Após replace (n): 11, 21, 31, 41". Porque `n` é passado `ByVal`, `replace` não é possível modificar a variável `n` no código de chamada atribuindo uma nova matriz. Quando `replace` cria a nova instância de matriz `k` e o atribui à variável local `a`, ele perde a referência à `n` passado pelo código de chamada. Quando ele é alterado os membros de `a`, somente a matriz local `k` é afetado. Portanto, `replace` não incrementa os valores de matriz `n` no código de chamada.  
   

--- a/docs/visual-basic/programming-guide/language-features/procedures/how-to-protect-a-procedure-argument-against-value-changes.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/how-to-protect-a-procedure-argument-against-value-changes.md
@@ -22,12 +22,12 @@ ms.lasthandoff: 05/04/2018
 ms.locfileid: "33651512"
 ---
 # <a name="how-to-protect-a-procedure-argument-against-value-changes-visual-basic"></a>Como proteger um argumento de procedimento contra alterações de valor (Visual Basic)
-Se um procedimento declara um parâmetro como [ByRef](../../../../visual-basic/language-reference/modifiers/byref.md), Visual Basic fornece o código do procedimento uma referência direta para o elemento de programação subjacente do argumento no código de chamada. Isso permite que o procedimento para alterar o valor subjacente do argumento no código de chamada. Em alguns casos, o código de chamada talvez queira proteger contra essa alteração.  
+Se um procedimento declara um parâmetro como [ByRef](../../../../visual-basic/language-reference/modifiers/byref.md), o Visual Basic passa para o procedimento uma referência direta para o elemento de programação subjacente do argumento no código de chamada. Isso permite que o procedimento altere o valor subjacente do argumento no código de chamada. Em alguns casos, o código de chamada talvez queira estar protegido contra essa alteração.  
   
- Você sempre pode proteger um argumento de alteração, declarando o parâmetro correspondente [ByVal](../../../../visual-basic/language-reference/modifiers/byval.md) no procedimento. Se desejar alterar um argumento fornecido em alguns casos, mas outros não, você pode declará-la `ByRef` e permitir que o código de chamada determinar o mecanismo de passagem em cada chamada. Ele faz isso colocando o argumento correspondente entre parênteses para passá-lo por valor ou não envolve em parênteses para passá-lo por referência. Para obter mais informações, consulte [como: forçar um argumento a ser passado por valor](./how-to-force-an-argument-to-be-passed-by-value.md).  
+ Você pode proteger um argumento de alteração, declarando o parâmetro correspondente com a palavra-chave [ByVal](../../../../visual-basic/language-reference/modifiers/byval.md) no procedimento. Se desejar alterar um argumento fornecido em alguns casos, mas outros não, você pode declará-la `ByRef` e permitir que o código de chamada determine o mecanismo de passagem em cada chamada. Ele faz isso colocando o argumento correspondente entre parênteses para passá-lo por valor, ou não envolvendo em parênteses para passá-lo por referência. Para obter mais informações, consulte [como: forçar um argumento a ser passado por valor](./how-to-force-an-argument-to-be-passed-by-value.md).  
   
 ## <a name="example"></a>Exemplo  
- O exemplo a seguir mostra dois procedimentos que tenham uma variável de matriz e operam em seus elementos. O `increase` procedimento simplesmente adiciona um para cada elemento. O `replace` procedimento atribui uma nova matriz para o parâmetro `a()` e, em seguida, adiciona um para cada elemento. No entanto, a reatribuição não afeta a variável array subjacente no código de chamada.  
+ O exemplo a seguir mostra dois procedimentos que tem uma variável de matriz e operam em seus elementos. O procedimento `increase` simplesmente adiciona um para cada elemento. O procedimento `replace` atribui uma nova matriz para o parâmetro `a()` e, em seguida, adiciona um para cada elemento. No entanto, a reatribuição não afeta a variável da array subjacente no código de chamada.  
   
  [!code-vb[VbVbcnProcedures#35](./codesnippet/VisualBasic/how-to-protect-a-procedure-argument-against-value-changes_1.vb)]  
   
@@ -35,12 +35,12 @@ Se um procedimento declara um parâmetro como [ByRef](../../../../visual-basic/l
   
  [!code-vb[VbVbcnProcedures#37](./codesnippet/VisualBasic/how-to-protect-a-procedure-argument-against-value-changes_3.vb)]  
   
- A primeira `MsgBox` chamada exibe "após increase (n): 11, 21, 31, 41". Porque a matriz `n` é um tipo de referência, `replace` pode alterar seus membros, mesmo que o mecanismo de passagem é `ByVal`.  
+ A primeira `MsgBox` chamada exibe "após increase (n): 11, 21, 31, 41". Porque a matriz `n` é um tipo de referência, `increase` pode alterar seus membros, mesmo que o mecanismo de passagem é `ByVal`.  
   
- O segundo `MsgBox` chamada exibe "Após Replace (n): 11, 21, 31, 41". Porque `n` é passado `ByVal`, `replace` não é possível modificar a variável `n` no código de chamada atribuindo uma nova matriz. Quando `replace` cria a nova instância de matriz `k` e o atribui à variável local `a`, ele perde a referência à `n` passado pelo código de chamada. Quando ele é alterado os membros de `a`, somente a matriz local `k` é afetado. Portanto, `replace` não incrementa os valores de matriz `n` no código de chamada.  
+ A segunda `MsgBox` chamada exibe "Após replace (n): 11, 21, 31, 41". Porque `n` é passado `ByVal`, `replace` não é possível modificar a variável `n` no código de chamada atribuindo uma nova matriz. Quando `replace` cria a nova instância de matriz `k` e o atribui à variável local `a`, ele perde a referência à `n` passado pelo código de chamada. Quando ele é alterado os membros de `a`, somente a matriz local `k` é afetado. Portanto, `replace` não incrementa os valores de matriz `n` no código de chamada.  
   
 ## <a name="compiling-the-code"></a>Compilando o código  
- O padrão no Visual Basic é passar argumentos por valor. No entanto, é uma boa prática para incluir qualquer um de programação de [ByVal](../../../../visual-basic/language-reference/modifiers/byval.md) ou [ByRef](../../../../visual-basic/language-reference/modifiers/byref.md) palavra-chave com cada parâmetro declarado. Isso facilita a leitura do seu código.  
+ O padrão no Visual Basic é passar argumentos por valor. No entanto, é uma boa prática de programação incluir as palavras-chave [ByVal](../../../../visual-basic/language-reference/modifiers/byval.md) ou [ByRef](../../../../visual-basic/language-reference/modifiers/byref.md) em cada parâmetro declarado. Isso facilita a leitura do seu código.  
   
 ## <a name="see-also"></a>Consulte também  
  [Procedimentos](./index.md)  


### PR DESCRIPTION
Most files in the PT-BR docs look like they were translated with google translate. This PR is fixing grammar mistakes in some files.

I also fixed a method name from the "how-to-protect-a-procedure-argument-against-value-changes.md" file based on this commit to the original documentation https://github.com/dotnet/docs/commit/a84470c09ea9ca83a8db812e1e510c18dd0405fa#diff-0699199c74fa7c2d422ec0ed17478eb1

Thank you,
Felipe